### PR TITLE
FEATURE: Allow user to enter RFC email for from address

### DIFF
--- a/code/MandrillMailer.php
+++ b/code/MandrillMailer.php
@@ -280,18 +280,29 @@ class MandrillMailer extends Mailer
         if (self::getDefaultParams()) {
             $default_params = self::getDefaultParams();
         }
+        if (is_array($from)) {
+            $fromEmail = $from['email'];
+            $fromName  = $from['name'];
+        }
+        else if(strpos($from, '<') !== false) {
+            $fromEmail = self::get_email_from_rfc_email($from);
+            $fromName = self::get_displayname_from_rfc_email($from);
+        }
+        else {
+            $fromEmail = $from;
+            $fromName = null;
+        }
+
         $params = array_merge($default_params,
             array(
             "subject" => $subject,
-            "from_email" => $from,
-            "to" => $to_array
+            "from_email" => $fromEmail,
+            "to" => $to
         ));
 
-        if (is_array($from)) {
-            $params['from_email'] = $from['email'];
-            $params['from_name']  = $from['name'];
+        if($fromName) {
+            $params['from_name'] = $fromName;
         }
-
         if ($plainContent) {
             $params['text'] = $plainContent;
         }


### PR DESCRIPTION
Currently, you have to pass an array: 
```php
['from_name' => 'My name', 'from_email' => 'me@example.com']
```

This change allows you to pass the more expected `My Name <me@example.com>'` as a from address to the mailer, which makes the transition to Mandrill much smoother.