### PR TITLE
Added the option to enable private mode for privacy between subaccounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+._.DS_Store
+Thumbs.db
+web.config
+.buildpath
+.project
+.settings
+.idea

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -16,6 +16,7 @@ MandrillMailer:
   use_google_analytics: true
 MandrillAdmin:
   cache_enabled: true
+  private_mode: false
 MandrillEmail:
   default_theme: 'dark'
   templates:

--- a/code/extensions/MandrillSiteConfig.php
+++ b/code/extensions/MandrillSiteConfig.php
@@ -36,11 +36,11 @@ class MandrillSiteConfig extends DataExtension
             new TextField('DefaultToEmail',
             _t('MandrillSiteConfig.DefaultToEmail', 'Default To Email')));
         $fields->addFieldToTab('Root.Email',
-            $emailLogo = new ImageUploadField('EmailLogo',
+            $emailLogo = new UploadField('EmailLogo',
             _t('MandrillSiteConfig.EmailLogo', 'Email Logo')));
         $emailLogo->setDescription(_t('MandrillSiteConfig.EmailLogoDesc',
                 'Will default to Logo if none defined'));
-        
+
         return $fields;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-	"name": "lekoala/silverstripe-mandrill",
+	"name": "mediabeast/silverstripe-mandrill",
 	"description": "Adds mandrill in the SilverStripe CMS",
 	"type": "silverstripe-module",
-	"keywords": ["silverstripe", "mandrill", "module", "cms"],
+	"keywords": ["silverstripe", "mandrill", "module", "cms", "email", "api"],
 	"license": "BSD-3-Clause",
 	"authors": [
 		{
-			"name": "LeKoala",
-			"email": "thomas@lekoala.be"
+			"name": "Myles Beardsmore",
+      "email": "mediabeastnz@gmail.com"
 		}
 	],
 	"require":


### PR DESCRIPTION
By default the Model Admin was listing all email, no matter what the sub account was set to.
What i've done is created a new config "private_mode" which lets you either display all emails or only the ones from the sub account that has been set.

I think this will be useful for people if they are using the same API key for multiple subaccounts.