### PR TITLE
Remove code field in CMS if already set

### DIFF
--- a/code/models/EmailTemplate.php
+++ b/code/models/EmailTemplate.php
@@ -104,6 +104,11 @@ class EmailTemplate extends DataObject
             _t('EmailTemplate.CODEPLACEHOLDER',
                 'A unique code that will be used in code to retrieve the template, e.g.: my-email'));
 
+        // Here we remove the code from the editor if it is set so clients can not update
+        if ($this->Code) {
+            $fields->removeByName('Code');
+        }
+
         // Merge fields helper
         $fields->addFieldToTab('Root.Main',
             new HeaderField('MergeFieldsHelperTitle',


### PR DESCRIPTION
Remove the code field if it is set so clients can not edit this. The code is used in controllers to send emails and so changing this could break email sending. 