### PR TITLE
Updated cache key

### DIFF
--- a/code/MandrillAdmin.php
+++ b/code/MandrillAdmin.php
@@ -308,7 +308,7 @@ class MandrillAdmin extends LeftAndMain implements PermissionProvider
         $enabled = $this->getCacheEnabled();
         if ($enabled) {
             $cache = $this->getCache();
-            $key = md5(serialize($params));
+            $key = $method . md5(serialize($params));
             $cacheResult = $cache->get($key);
         }
         if ($enabled && $cacheResult) {


### PR DESCRIPTION
Using the parameters does not make the key unique. By adding the method name we can create a unique key for the method request. Otherwise if the parameters are empty you get the wrong data.