### PR TITLE
webhook authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ MandrillController provides 4 extensions points:
 -   updateHandleInboundEvent
 -   updateHandleMessageEvent
 
+It's recommended that you ensure requests are coming from Mailchimp Transactional rather than an imitator.
+Webhook authentication is disabled by default but you can enable webhook authentication through the config layer like so:
+
+```
+LeKoala\Mandrill\MandrillController:
+  webhook_auth_enabled: true
+```
+
+You'll need your webhook authentication key which you can view and reset from the (Webhooks)[https://mandrillapp.com/settings/webhooks] page in your account.
+Add your key using the config layer or `.env` file.
+
+via config
+```
+LeKoala\Mandrill\MandrillController:
+  webhook_key: YOUR_KEY
+```
+
+via .env file
+```
+MANDRILL_WEB_HOOK_KEY=YOUR_KEY
+```
+
 # Swift Mailer 6
 
 Swift Mailer 6 introduced quite a lot of breaking changes, make sure you are not using any of those:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ LeKoala\Mandrill\MandrillController:
 
 via .env file
 ```
-MANDRILL_WEB_HOOK_KEY=YOUR_KEY
+MANDRILL_WEBHOOK_KEY=YOUR_KEY
 ```
 
 # Swift Mailer 6

--- a/code/MandrillController.php
+++ b/code/MandrillController.php
@@ -152,15 +152,15 @@ class MandrillController extends Controller
         $data = MandrillAdmin::create()->singleton()->WebhookUrl();
         $key = Environment::getEnv('MANDRILL_WEBHOOK_KEY');
 
+        if (self::config()->webhook_key) {
+            $key = self::config()->webhook_key;
+        }
+
         foreach ($postVars as $key => $value) {
             $data .= $key;
             $data .= $value;
         }
 
-        if (self::config()->webhook_key) {
-            $key = self::config()->webhook_key;
-        }
-
-        return base64_encode(hash_hmac('sha1', $data, Environment::getEnv('MANDRILL_WEBHOOK_KEY'), true));
+        return base64_encode(hash_hmac('sha1', $data, $key, true));
     }
 }

--- a/code/MandrillController.php
+++ b/code/MandrillController.php
@@ -68,7 +68,7 @@ class MandrillController extends Controller
         $response->setStatusCode(200);
         $response->setBody('');
 
-        //make sure the generated signature matches the X-Mandrill-Signature header if webook auth is enabled
+        //make sure the generated signature matches the X-Mandrill-Signature header
         if (self::config()->webhook_auth_enabled && $generatedSignature !== $mandrillSignature) {
             return $response;
         }

--- a/code/MandrillController.php
+++ b/code/MandrillController.php
@@ -143,7 +143,7 @@ class MandrillController extends Controller
      * generates signature to verify request is from mailchimp.
      * see https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/#authenticating-webhook-requests
      *
-     * @param Array @postVars
+     * @param Array $postVars
      * @return string
      */
     protected function generateSignature(array $postVars)

--- a/code/MandrillController.php
+++ b/code/MandrillController.php
@@ -140,6 +140,22 @@ class MandrillController extends Controller
     }
 
     /**
+     * returns the webhook key
+     *
+     * @return string
+     */
+    public function getWebHookKey()
+    {
+        $key = Environment::getEnv('MANDRILL_WEBHOOK_KEY');
+
+        if (self::config()->webhook_key) {
+            $key = self::config()->webhook_key;
+        }
+
+        return $key;
+    }
+
+    /**
      * generates signature to verify request is from mailchimp.
      * see https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/#authenticating-webhook-requests
      *
@@ -150,17 +166,13 @@ class MandrillController extends Controller
     {
         ksort($postVars);
         $data = MandrillAdmin::create()->singleton()->WebhookUrl();
-        $key = Environment::getEnv('MANDRILL_WEBHOOK_KEY');
-
-        if (self::config()->webhook_key) {
-            $key = self::config()->webhook_key;
-        }
+        $webHookKey = $this->getWebHookKey();
 
         foreach ($postVars as $key => $value) {
             $data .= $key;
             $data .= $value;
         }
 
-        return base64_encode(hash_hmac('sha1', $data, $key, true));
+        return base64_encode(hash_hmac('sha1', $data, $webHookKey, true));
     }
 }

--- a/code/MandrillController.php
+++ b/code/MandrillController.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Environment;
 
 /**
  * Provide extensions points for handling the webhook
@@ -32,6 +33,8 @@ class MandrillController extends Controller
         'incoming',
     ];
 
+    private static $webhook_auth_enabled = false;
+
     /**
      * Inject public dependencies into the controller
      *
@@ -56,12 +59,19 @@ class MandrillController extends Controller
      */
     public function incoming(HTTPRequest $req)
     {
+        $generatedSignature = $this->generateSignature($req->postVars());
+        $mandrillSignature = $req->getHeader('X-Mandrill-Signature');
         $json = $req->postVar('mandrill_events');
 
         // By default, return a valid response
         $response = $this->getResponse();
         $response->setStatusCode(200);
         $response->setBody('');
+
+        //make sure the generated signature matches the X-Mandrill-Signature header if webook auth is enabled
+        if (self::config()->webhook_auth_enabled && $generatedSignature !== $mandrillSignature) {
+            return $response;
+        }
 
         if (!$json) {
             return $response;
@@ -74,16 +84,16 @@ class MandrillController extends Controller
 
             $event = $ev->event;
             switch ($event) {
-                    // Sync type
+                // Sync type
                 case self::EVENT_BLACKLIST:
                 case self::EVENT_WHITELIST:
                     $this->handleSyncEvent($ev);
                     break;
-                    // Inbound type
+                // Inbound type
                 case self::EVENT_INBOUND:
                     $this->handleInboundEvent($ev);
                     break;
-                    // Message type
+                // Message type
                 case self::EVENT_CLICK:
                 case self::EVENT_HARD_BOUNCE:
                 case self::EVENT_OPEN:
@@ -127,5 +137,30 @@ class MandrillController extends Controller
     public function getLogger()
     {
         return $this->logger;
+    }
+
+    /**
+     * generates signature to verify request is from mailchimp.
+     * see https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/#authenticating-webhook-requests
+     *
+     * @param Array @postVars
+     * @return string
+     */
+    protected function generateSignature(array $postVars)
+    {
+        ksort($postVars);
+        $data = MandrillAdmin::create()->singleton()->WebhookUrl();
+        $key = Environment::getEnv('MANDRILL_WEBHOOK_KEY');
+
+        foreach ($postVars as $key => $value) {
+            $data .= $key;
+            $data .= $value;
+        }
+
+        if (self::config()->webhook_key) {
+            $key = self::config()->webhook_key;
+        }
+
+        return base64_encode(hash_hmac('sha1', $data, Environment::getEnv('MANDRILL_WEBHOOK_KEY'), true));
     }
 }


### PR DESCRIPTION
This adds optional authentication to the webhook controller. See https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/#authenticating-webhook-requests for reference.

I've tested this code lightly but fairly confident it should work. Updated the readme as well with notes on how to enable authentication.