### PR TITLE
Dynamic vars and composer changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
         "silverstripe/framework": "^5",
         "composer/ca-bundle": "^1.1",
         "symfony/mailchimp-mailer": "^6.3",
-        "symbiote/silverstripe-gridfieldextensions": "^4.0"
+        "symbiote/silverstripe-gridfieldextensions": "^4.0",
+        "symfony/http-client": "^5.4|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.5",
-        "symfony/http-client": "^5.4|^6.0"
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "extra": {
         "expose": [

--- a/src/thirdparty/Mandrill/Exports.php
+++ b/src/thirdparty/Mandrill/Exports.php
@@ -3,6 +3,8 @@
 class Mandrill_Exports
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Inbound.php
+++ b/src/thirdparty/Mandrill/Inbound.php
@@ -3,6 +3,8 @@
 class Mandrill_Inbound
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Internal.php
+++ b/src/thirdparty/Mandrill/Internal.php
@@ -3,6 +3,8 @@
 class Mandrill_Internal
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Ips.php
+++ b/src/thirdparty/Mandrill/Ips.php
@@ -3,6 +3,8 @@
 class Mandrill_Ips
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Messages.php
+++ b/src/thirdparty/Mandrill/Messages.php
@@ -3,6 +3,8 @@
 class Mandrill_Messages
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Metadata.php
+++ b/src/thirdparty/Mandrill/Metadata.php
@@ -3,6 +3,8 @@
 class Mandrill_Metadata
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Rejects.php
+++ b/src/thirdparty/Mandrill/Rejects.php
@@ -3,6 +3,8 @@
 class Mandrill_Rejects
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Senders.php
+++ b/src/thirdparty/Mandrill/Senders.php
@@ -3,6 +3,8 @@
 class Mandrill_Senders
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Subaccounts.php
+++ b/src/thirdparty/Mandrill/Subaccounts.php
@@ -3,6 +3,8 @@
 class Mandrill_Subaccounts
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Tags.php
+++ b/src/thirdparty/Mandrill/Tags.php
@@ -3,6 +3,8 @@
 class Mandrill_Tags
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Templates.php
+++ b/src/thirdparty/Mandrill/Templates.php
@@ -3,6 +3,8 @@
 class Mandrill_Templates
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Urls.php
+++ b/src/thirdparty/Mandrill/Urls.php
@@ -3,6 +3,8 @@
 class Mandrill_Urls
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Users.php
+++ b/src/thirdparty/Mandrill/Users.php
@@ -3,6 +3,8 @@
 class Mandrill_Users
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Webhooks.php
+++ b/src/thirdparty/Mandrill/Webhooks.php
@@ -3,6 +3,8 @@
 class Mandrill_Webhooks
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;

--- a/src/thirdparty/Mandrill/Whitelists.php
+++ b/src/thirdparty/Mandrill/Whitelists.php
@@ -3,6 +3,8 @@
 class Mandrill_Whitelists
 {
 
+    private $master;
+
     public function __construct(Mandrill $master)
     {
         $this->master = $master;


### PR DESCRIPTION
Deprecation fix for PHP8.2 dynamic vars + move symfony/http-client out of require-dev to prevent error on dev/build